### PR TITLE
docker push and coveralls report only in master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ install:
   - docker build -t tylerreddy/steric-conflicts docker_build/
 
 script:
-  - docker run -e "COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN" -i -t tylerreddy/steric-conflicts /bin/sh -c "cd /steric_analysis; nosetests --verbosity=3 --with-coverage --cover-package steric_assessment_general tests.py 2>&1 | tee nose.log; coveralls; tail -1 nose.log | grep -q OK"
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+     docker run -e "COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN" tylerreddy/steric-conflicts /bin/sh -c "cd /steric_analysis; nosetests --verbosity=3 --with-coverage --cover-package steric_assessment_general tests.py 2>&1 | tee nose.log; coveralls; tail -1 nose.log | grep -q OK";
+    else 
+     docker run tylerreddy/steric-conflicts /bin/sh -c "cd /steric_analysis; nosetests --verbosity=3 --with-coverage --cover-package steric_assessment_general tests.py 2>&1 | tee nose.log; tail -1 nose.log | grep -q OK";
+    fi
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,7 @@ script:
   - docker run -e "COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN" -i -t tylerreddy/steric-conflicts /bin/sh -c "cd /steric_analysis; nosetests --verbosity=3 --with-coverage --cover-package steric_assessment_general tests.py 2>&1 | tee nose.log; coveralls; tail -1 nose.log | grep -q OK"
 
 after_success:
-  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker push tylerreddy/steric-conflicts
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+     docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+     docker push tylerreddy/steric-conflicts;
+    fi


### PR DESCRIPTION
`travis.yml` has been adjusted to only run `docker push` on the master branch, as I don't want the `tylerreddy/steric-conflicts:latest` docker image to be populated by any random pull request docker build that succeeds.

Furthermore, the submission of coveralls reports online has also been restricted to the master branch (this can be inspected manually in travis-ci logs easily enough for PR branches).
