### PR TITLE
Library version pindown in Dockerfile

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -18,7 +18,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 
 ENV PATH /opt/conda/bin:$PATH
 
-RUN conda install numpy scipy
+RUN conda install numpy=1.11.0 scipy=0.17.0
 RUN conda config --add channels MDAnalysis && conda install mdanalysis=0.14
 RUN pip install coveralls
 


### PR DESCRIPTION
A simple PR that pins down a few library versions in the Dockerfile in an attempt to increase future usability of the workflow.
