### PR TITLE
Switch to using dev branch of MDA in docker image

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -18,8 +18,9 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 
 ENV PATH /opt/conda/bin:$PATH
 
-RUN conda install numpy=1.11.0 scipy=0.17.0
-RUN conda config --add channels MDAnalysis && conda install mdanalysis=0.14
+RUN conda install numpy=1.11.0 scipy=0.17.0 cython nose
+RUN git clone https://github.com/MDAnalysis/mdanalysis.git /src/mdanalysis
+RUN pip install -e /src/mdanalysis/package
 RUN pip install coveralls
 
 ADD *py /steric_analysis/


### PR DESCRIPTION
PR to fix Issue #6. Basically I want the docker image to build using the development version of MDAnalysis because the downstream steric conflict resolution code depends on fixes in the development branch to write large .gro files with proper residue number formatting.
